### PR TITLE
Add standard health endpoints (/, /healthz)

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1,20 +1,26 @@
+// src/app.js
 const express = require('express');
 const app = express();
-const cors = require('cors')
+const cors = require('cors');
 const favicon = require('express-favicon');
 const logger = require('morgan');
 
 const mainRouter = require('./routes/mainRouter.js');
 
-// middleware
 app.use(cors());
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 app.use(logger('dev'));
-app.use(express.static('public'))
+
+// Health endpoints (before static)
+app.get('/', (_req, res) => res.status(200).send('Retrieve API v1'));
+app.get('/healthz', (_req, res) => res.status(200).json({ status: 'ok' }));
+
+// Static (after health so "/" isn’t intercepted)
+app.use(express.static('public'));
 app.use(favicon(__dirname + '/public/favicon.ico'));
 
-// routes
+// API
 app.use('/api/v1', mainRouter);
 
 module.exports = app;


### PR DESCRIPTION
Adds standard root endpoints
GET / → "Retrieve API v1" (smoke check)
GET /healthz → {"status":"ok"} (200) (liveness probe)
Mounted before static so / isn’t intercepted.
No changes to /api/v1.

Quick way to confirm the backend is alive (locally and in deploys)
Works with common monitors/uptime checks
Version-agnostic, no DB/auth involved, very fast