### PR TITLE
SCRUM-24 - Postman Collection: DB health check requests 

### DIFF
--- a/postman/Retrieve.postman_environment.json
+++ b/postman/Retrieve.postman_environment.json
@@ -1,0 +1,15 @@
+{
+	"id": "aa145f95-0067-46d7-8a2b-b6419cb1508b",
+	"name": "Retrieve",
+	"values": [
+		{
+			"key": "base_url",
+			"value": "http://localhost:8000",
+			"type": "default",
+			"enabled": true
+		}
+	],
+	"_postman_variable_scope": "environment",
+	"_postman_exported_at": "2025-08-31T05:15:21.257Z",
+	"_postman_exported_using": "Postman/11.54.6"
+}

--- a/postman/RetrieveAPI.postman_collection.json
+++ b/postman/RetrieveAPI.postman_collection.json
@@ -1,0 +1,45 @@
+{
+	"info": {
+		"_postman_id": "d79ec9cb-aff4-49de-bab4-970a4e9fb9c8",
+		"name": "Retrieve API",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "4029503"
+	},
+	"item": [
+		{
+			"name": "Healthz",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{base_url}}/healthz",
+					"host": [
+						"{{base_url}}"
+					],
+					"path": [
+						"healthz"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Healthz DB",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{base_url}}/healthz/db",
+					"host": [
+						"{{base_url}}"
+					],
+					"path": [
+						"healthz",
+						"db"
+					]
+				}
+			},
+			"response": []
+		}
+	]
+}


### PR DESCRIPTION
- Added Postman environment with base_url 
- Added health check requests:  GET /healthz and GET /healthz/db
to validate overall application health and database connectivity

<img width="1649" height="859" alt="Retrieve_Postman environment" src="https://github.com/user-attachments/assets/19871189-34e9-4105-b79a-64e008cc20e1" />

<img width="1648" height="849" alt="Retrieve_GET_healthz" src="https://github.com/user-attachments/assets/a22699f4-684b-4420-82c9-a4c0c628f3d0" />

<img width="1633" height="840" alt="Retrieve_GET_healthz_DB" src="https://github.com/user-attachments/assets/b87ec783-f30c-47a8-8279-f450d613f0dc" />
