### PR TITLE
Profile GET/PATCH + avatar upload/delete (Cloudinary)

### DIFF
--- a/prisma/migrations/20250910171507_user_avatar_public_id/migration.sql
+++ b/prisma/migrations/20250910171507_user_avatar_public_id/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "public"."users" ADD COLUMN     "avatar_public_id" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -17,6 +17,7 @@ model User {
   phoneNumber          String?       @map("phone_number")
   zipCode              String        @map("zip_code")
   avatarUrl            String?       @map("avatar_url")
+  avatarPublicId    String?       @map("avatar_public_id")
   createdAt            DateTime      @default(now()) @map("created_at")
   updatedAt            DateTime      @updatedAt @map("updated_at")
   comments             ItemComment[] @relation("UserComments")
@@ -25,6 +26,7 @@ model User {
   seenMarks            SeenMark[]
   threadsAsOwner       Thread[]      @relation("OwnerThreads")
   threadsAsParticipant Thread[]      @relation("ParticipantThreads")
+  
 
   @@map("users")
 }

--- a/src/controllers/users/users.controller.js
+++ b/src/controllers/users/users.controller.js
@@ -1,0 +1,128 @@
+// User profile controller
+const { PrismaClient } = require('@prisma/client');
+const prisma = new PrismaClient();
+const cloudinary = require('../../config/cloudinary');
+
+// helpers
+function uploadBuffer(buffer, options = {}) {
+  return new Promise((resolve, reject) => {
+    const stream = cloudinary.uploader.upload_stream(options, (err, result) => {
+      if (err) return reject(err);
+      resolve(result);
+    });
+    stream.end(buffer);
+  });
+}
+
+const userSelect = {
+  id: true,
+  firstName: true,
+  lastName: true,
+  email: true,
+  phoneNumber: true,
+  zipCode: true,
+  avatarUrl: true,
+  avatarPublicId: true,
+  createdAt: true,
+  updatedAt: true,
+};
+
+// GET /api/v1/users/self
+async function getSelf(req, res, next) {
+  try {
+    const user = await prisma.user.findUnique({
+      where: { id: req.user.id },
+      select: userSelect,
+    });
+    return res.status(200).json({ success: true, data: user });
+  } catch (err) {
+    next(err);
+  }
+}
+
+// PATCH /api/v1/users/self
+async function updateSelf(req, res, next) {
+  try {
+    const { firstName, lastName, phoneNumber, zipCode } = req.body;
+
+    const user = await prisma.user.update({
+      where: { id: req.user.id },
+      data: { firstName, lastName, phoneNumber, zipCode },
+      select: userSelect,
+    });
+
+    return res.status(200).json({ success: true, data: user });
+  } catch (err) {
+    next(err);
+  }
+}
+
+// POST /api/v1/users/self/avatar
+async function uploadAvatar(req, res, next) {
+  try {
+    if (!req.file) {
+      const e = new Error('No file uploaded');
+      e.status = 422;
+      e.code = 'UNPROCESSABLE_ENTITY';
+      throw e;
+    }
+
+    const current = await prisma.user.findUnique({
+      where: { id: req.user.id },
+      select: { avatarPublicId: true },
+    });
+
+    if (current?.avatarPublicId) {
+      // best-effort delete
+      await cloudinary.uploader.destroy(current.avatarPublicId).catch(() => {});
+    }
+
+    const result = await uploadBuffer(req.file.buffer, {
+      folder: `avatars/users/${req.user.id}`,
+      resource_type: 'image',
+      overwrite: true,
+      transformation: [{ width: 400, height: 400, crop: 'fill', gravity: 'auto' }],
+    });
+
+    const user = await prisma.user.update({
+      where: { id: req.user.id },
+      data: { avatarUrl: result.secure_url, avatarPublicId: result.public_id },
+      select: userSelect,
+    });
+
+    return res.status(200).json({ success: true, data: user });
+  } catch (err) {
+    next(err);
+  }
+}
+
+// DELETE /api/v1/users/self/avatar
+async function deleteAvatar(req, res, next) {
+  try {
+    const current = await prisma.user.findUnique({
+      where: { id: req.user.id },
+      select: { avatarPublicId: true },
+    });
+
+    if (current?.avatarPublicId) {
+      await cloudinary.uploader.destroy(current.avatarPublicId).catch(() => {});
+    }
+
+    const user = await prisma.user.update({
+      where: { id: req.user.id },
+      data: { avatarUrl: null, avatarPublicId: null },
+      select: userSelect,
+    });
+
+    return res.status(200).json({ success: true, data: user });
+  } catch (err) {
+    next(err);
+  }
+}
+
+module.exports = {
+  getSelf,
+  updateSelf,
+  uploadAvatar,
+  deleteAvatar,
+};

--- a/src/middleware/avatarUpload.js
+++ b/src/middleware/avatarUpload.js
@@ -1,0 +1,18 @@
+const multer = require('multer');
+
+const storage = multer.memoryStorage();
+
+const fileFilter = (req, file, cb) => {
+  const allowed = ['image/jpeg', 'image/png', 'image/webp'];
+  if (allowed.includes(file.mimetype)) return cb(null, true);
+  const err = new Error('Unsupported file type');
+  err.status = 415;
+  err.code = 'UNSUPPORTED_MEDIA_TYPE';
+  cb(err);
+};
+
+module.exports = multer({
+  storage,
+  limits: { fileSize: 2 * 1024 * 1024 }, // 2MB
+  fileFilter,
+}).single('avatar'); // form-data field name = avatar

--- a/src/routes/items/items.router.js
+++ b/src/routes/items/items.router.js
@@ -16,6 +16,7 @@ const {
 const querySchema = require('../../validators/items/query.schema');
 
 const { seenMarkSchema, seenIdParamSchema } = require('../../validators/seen/seenMark.validator');
+const { paginationSchema } = require('../../validators/items/query.schema');
 
 
 // GET /items — list with filters, geo, pagination/sort
@@ -88,6 +89,8 @@ router.post(
   requireAuth,
   validate({ params: idParamSchema, body: createItemCommentSchema }),
   commentsController.postItemComment
+);
+
 // POST /items/:id/seen
 router.post(
   '/:id/seen',
@@ -95,6 +98,7 @@ router.post(
   validate({ params: idParamSchema, body: seenMarkSchema }),
   seenController.postSeenMark
 );
+
 
 // GET /items/:id/seen
 router.get(

--- a/src/routes/mainRouter.js
+++ b/src/routes/mainRouter.js
@@ -8,6 +8,7 @@ const categoriesRouter = require('./categories/categories.router.js');
 const itemsRouter = require('./items/items.router.js');
 const uploadsRouter = require('./uploads/uploads.router.js');
 const commentsRouter = require('./comments/comments.router.js');
+const usersRouter = require('./users/users.routes.js');
 
 // Root
 router.get('/', mainController.get);
@@ -35,6 +36,8 @@ router.use('/comments', commentsRouter);
 
 // Uploads module: /api/v1/uploads
 router.use('/uploads', uploadsRouter);
+
+router.use('/users', usersRouter);
 
 module.exports = router;
 

--- a/src/routes/users/users.routes.js
+++ b/src/routes/users/users.routes.js
@@ -1,0 +1,22 @@
+// User profile routes
+const router = require('express').Router();
+
+const {requireAuth} = require('../../middleware/auth');
+const validate = require('../../middleware/validate');
+const { updateProfileBodySchema } = require('../../validators/users/updateProfile.schema');
+const usersController = require('../../controllers/users/users.controller');
+const avatarUpload = require('../../middleware/avatarUpload');
+
+// GET /api/v1/users/self
+router.get('/self', requireAuth, usersController.getSelf);
+
+// PATCH /api/v1/users/self
+router.patch('/self', requireAuth, validate({ body: updateProfileBodySchema }), usersController.updateSelf);
+
+// POST /api/v1/users/self/avatar
+router.post('/self/avatar', requireAuth, avatarUpload, usersController.uploadAvatar);
+
+// DELETE /api/v1/users/self/avatar
+router.delete('/self/avatar', requireAuth, usersController.deleteAvatar);
+
+module.exports = router;

--- a/src/validators/users/updateProfile.schema.js
+++ b/src/validators/users/updateProfile.schema.js
@@ -1,0 +1,14 @@
+const { z } = require('zod');
+
+const E164 = /^\+?[1-9]\d{1,14}$/;
+
+const updateProfileBodySchema = z
+  .object({
+    firstName: z.string().trim().min(2).max(60).optional(),
+    lastName: z.string().trim().min(2).max(60).optional(),
+    phoneNumber: z.string().trim().regex(E164, 'Phone must be E.164 like +11234567890').optional(),
+    zipCode: z.string().trim().min(3).max(10).optional(),
+  })
+  .strict();
+
+module.exports = { updateProfileBodySchema };


### PR DESCRIPTION
- Added /api/v1/users/self (GET) and /self (PATCH) with Zod validation
- Implemented avatar upload/delete via Cloudinary:
  * POST /api/v1/users/self/avatar
  * DELETE /api/v1/users/self/avatar
- Added multer middleware for avatar upload (2MB, jpeg/png/webp)
- Prisma: added users.avatar_public_id
- Connected users routes in mainRouter
- Updated controllers, validators, and routes
- Added Postman endpoints for testing

<img width="780" height="629" alt="Screenshot 2025-09-10 at 2 00 01 PM" src="https://github.com/user-attachments/assets/2a600489-5fd9-4db6-9348-ec8ef46674a6" />
<img width="1318" height="472" alt="Screenshot 2025-09-10 at 2 12 19 PM" src="https://github.com/user-attachments/assets/5800b67a-b970-400f-9f44-9fa548544fa8" />
<img width="635" height="580" alt="Screenshot 2025-09-10 at 2 14 05 PM" src="https://github.com/user-attachments/assets/0a416af5-2ac9-4a42-aa43-39afb95694b7" />