### PR TITLE
feat(threads): extend GET /threads with item and otherUser

### DIFF
--- a/src/repositories/threads/threads.repository.js
+++ b/src/repositories/threads/threads.repository.js
@@ -49,11 +49,34 @@ async function listThreadsForUser(userId, { itemId, page = 1, size = 20 }) {
       skip,
       take,
       orderBy: { updatedAt: 'desc' },
+      include: {
+        item: {
+          select: { id: true, title: true, status: true },
+        },
+        owner: {
+          select: { id: true, firstName: true, lastName: true, avatarUrl: true },
+        },
+        participant: {
+          select: { id: true, firstName: true, lastName: true, avatarUrl: true },
+        },
+      },
     }),
     prisma.thread.count({ where }),
   ]);
 
-  return { threads, total, page, size };
+  // Map to include `otherUser`
+  const mapped = threads.map((t) => {
+    const otherUser =
+      t.ownerId === userId ? t.participant : t.owner;
+
+    return {
+      ...t,
+      item: t.item,
+      otherUser,
+    };
+  });
+
+  return { threads: mapped, total, page, size };
 }
 
 // Mark thread messages as read up to a messageId
@@ -104,10 +127,14 @@ async function countUnreadForUser(userId) {
   for (const t of threads) {
     if (t.ownerId === userId) {
       const lastReadAt = t.ownerLastReadAt || new Date(0);
-      totalUnread += t.messages.filter(m => m.createdAt > lastReadAt && m.senderId !== userId).length;
+      totalUnread += t.messages.filter(
+        (m) => m.createdAt > lastReadAt && m.senderId !== userId
+      ).length;
     } else if (t.participantId === userId) {
       const lastReadAt = t.participantLastReadAt || new Date(0);
-      totalUnread += t.messages.filter(m => m.createdAt > lastReadAt && m.senderId !== userId).length;
+      totalUnread += t.messages.filter(
+        (m) => m.createdAt > lastReadAt && m.senderId !== userId
+      ).length;
     }
   }
 


### PR DESCRIPTION
extends GET /api/v1/threads to return:

item: { id, title, status }

otherUser: { id, firstName, lastName, avatarUrl } relative to the authenticated user.

No breaking changes; existing fields remain unchanged.
<img width="936" height="965" alt="Screenshot 2025-09-15 at 8 41 30 PM" src="https://github.com/user-attachments/assets/e6b40138-8a06-4b9a-b6c6-1128697360bf" />
