### PR TITLE
include item photos in responses (items & threads)

### DIFF
--- a/src/controllers/items/items.controller.js
+++ b/src/controllers/items/items.controller.js
@@ -34,7 +34,9 @@ async function getItems(req, res, next) {
         sortBy: q.sortBy,
         sortOrder: q.sortOrder,
       },
-      { page: q.page, limit: q.limit, offset: q.offset }
+      { page: q.page, limit: q.limit, offset: q.offset },
+      // Ask service to include photos in the payloads
+      { includePhotos: true }
     );
 
     return res.json({
@@ -58,7 +60,8 @@ async function getItems(req, res, next) {
 async function getItemById(req, res, next) {
   try {
     const id = (req.validatedParams && req.validatedParams.id) || req.params.id;
-    const item = await itemsService.getItemById(id);
+    // Ask service to include photos for single item as well
+    const item = await itemsService.getItemById(id, { includePhotos: true });
     if (!item) {
       return res.status(StatusCodes.NOT_FOUND).json({
         success: false,

--- a/src/repositories/threads/threads.repository.js
+++ b/src/repositories/threads/threads.repository.js
@@ -4,17 +4,45 @@ const { prisma } = require('../../utils/prisma');
 async function getOrCreateThread({ itemId, ownerId, participantId }) {
   try {
     // Try to find existing thread
-    const existing = await prisma.thread.findUnique({
+    let existing = await prisma.thread.findUnique({
       where: { itemId_participantId: { itemId, participantId } },
+      // Return rich payload so the client can render right away
+      include: {
+        item: {
+          select: {
+            id: true, title: true, status: true,
+            photos: {
+              select: { id: true, url: true, createdAt: true },
+              orderBy: { createdAt: 'asc' }, // oldest → newest
+            },
+          },
+        },
+        owner: { select: { id: true, firstName: true, lastName: true, avatarUrl: true } },
+        participant: { select: { id: true, firstName: true, lastName: true, avatarUrl: true } },
+      },
     });
     if (existing) return { thread: existing, created: false };
 
     // Otherwise create new
-    const thread = await prisma.thread.create({
-      data: {
-        itemId,
-        ownerId,
-        participantId,
+    await prisma.thread.create({
+      data: { itemId, ownerId, participantId },
+    });
+
+    // Fetch with include for consistent shape
+    const thread = await prisma.thread.findUnique({
+      where: { itemId_participantId: { itemId, participantId } },
+      include: {
+        item: {
+          select: {
+            id: true, title: true, status: true,
+            photos: {
+              select: { id: true, url: true, createdAt: true },
+              orderBy: { createdAt: 'asc' },
+            },
+          },
+        },
+        owner: { select: { id: true, firstName: true, lastName: true, avatarUrl: true } },
+        participant: { select: { id: true, firstName: true, lastName: true, avatarUrl: true } },
       },
     });
     return { thread, created: true };
@@ -22,6 +50,19 @@ async function getOrCreateThread({ itemId, ownerId, participantId }) {
     if (err.code === 'P2002') {
       const thread = await prisma.thread.findUnique({
         where: { itemId_participantId: { itemId, participantId } },
+        include: {
+          item: {
+            select: {
+              id: true, title: true, status: true,
+              photos: {
+                select: { id: true, url: true, createdAt: true },
+                orderBy: { createdAt: 'asc' },
+              },
+            },
+          },
+          owner: { select: { id: true, firstName: true, lastName: true, avatarUrl: true } },
+          participant: { select: { id: true, firstName: true, lastName: true, avatarUrl: true } },
+        },
       });
       return { thread, created: false };
     }
@@ -35,13 +76,8 @@ async function listThreadsForUser(userId, { itemId, page = 1, size = 20 }) {
   const take = size;
 
   const where = itemId
-    ? {
-        itemId,
-        OR: [{ ownerId: userId }, { participantId: userId }],
-      }
-    : {
-        OR: [{ ownerId: userId }, { participantId: userId }],
-      };
+    ? { itemId, OR: [{ ownerId: userId }, { participantId: userId }] }
+    : { OR: [{ ownerId: userId }, { participantId: userId }] };
 
   const [threads, total] = await Promise.all([
     prisma.thread.findMany({
@@ -49,6 +85,20 @@ async function listThreadsForUser(userId, { itemId, page = 1, size = 20 }) {
       skip,
       take,
       orderBy: { updatedAt: 'desc' },
+      // Include item photos and user avatars for UI rendering
+      include: {
+        item: {
+          select: {
+            id: true, title: true, status: true,
+            photos: {
+              select: { id: true, url: true, createdAt: true },
+              orderBy: { createdAt: 'asc' }, // oldest first
+            },
+          },
+        },
+        owner: { select: { id: true, firstName: true, lastName: true, avatarUrl: true } },
+        participant: { select: { id: true, firstName: true, lastName: true, avatarUrl: true } },
+      },
     }),
     prisma.thread.count({ where }),
   ]);
@@ -65,24 +115,15 @@ async function markThreadAsRead(threadId, userId, messageId) {
     // Only participants (owner or participant) can mark reads
     let updateData = {};
     if (thread.ownerId === userId) {
-      updateData = {
-        ownerLastReadMessageId: messageId,
-        ownerLastReadAt: new Date(),
-      };
+      updateData = { ownerLastReadMessageId: messageId, ownerLastReadAt: new Date() };
     } else if (thread.participantId === userId) {
-      updateData = {
-        participantLastReadMessageId: messageId,
-        participantLastReadAt: new Date(),
-      };
+      updateData = { participantLastReadMessageId: messageId, participantLastReadAt: new Date() };
     } else {
       // Not authorized
       return 'forbidden';
     }
 
-    return prisma.thread.update({
-      where: { id: threadId },
-      data: updateData,
-    });
+    return prisma.thread.update({ where: { id: threadId }, data: updateData });
   } catch (err) {
     console.error('Error in markThreadAsRead:', err);
     throw err; // let controller handle it
@@ -93,9 +134,7 @@ async function markThreadAsRead(threadId, userId, messageId) {
 async function countUnreadForUser(userId) {
   // Fetch threads where the user participates
   const threads = await prisma.thread.findMany({
-    where: {
-      OR: [{ ownerId: userId }, { participantId: userId }],
-    },
+    where: { OR: [{ ownerId: userId }, { participantId: userId }] },
     include: { messages: true },
   });
 


### PR DESCRIPTION
- Added optional photos relation for items (findMany, findById, findByOwner).
- Exposed primaryPhotoUrl for easier rendering on the frontend.
- Updated threads response to include item photo via relation.
- Keeps backward compatibility (photos only included when requested).
<img width="1239" height="834" alt="Screenshot 2025-09-17 at 1 47 56 PM" src="https://github.com/user-attachments/assets/d43d22e1-eb29-4991-8f28-849aedf7fcfe" />
